### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,7 +38,7 @@ Required dependencies for compiling the code, in a Debian/Ubuntu based
 distribution run:
 
 ```bash
-sudo apt install cmake pkg-config libbrotli-dev
+sudo apt install cmake pkg-config libbrotli-dev libstdc++-12-dev
 ```
 
 Optional dependencies for supporting other formats in the `cjxl`/`djxl` tools,


### PR DESCRIPTION
`cmake` requires a version of `lstdc++` or the command fails with error _"/usr/bin/ld: cannot find -lstdc++: No such file or directory"_